### PR TITLE
Add support for removing table prefixes

### DIFF
--- a/config/models.php
+++ b/config/models.php
@@ -264,6 +264,17 @@ return [
         'except' => [
             'migrations',
         ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Table Prefix
+        |--------------------------------------------------------------------------
+        |
+        | If you have a prefix on your table names but don't want it in the model
+        | and relation names, specify it here.
+        |
+        */
+        'table_prefix' => '',
     ],
 
     /*

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -153,6 +153,11 @@ class Model
     protected $hasCrossDatabaseRelationships = false;
 
     /**
+     * @var string
+     */
+    protected $tablePrefix = '';
+
+    /**
      * ModelClass constructor.
      *
      * @param \Reliese\Meta\Blueprint $blueprint
@@ -193,6 +198,9 @@ class Model
 
         // Dates settings
         $this->withDateFormat($this->config('date_format', $this->getDefaultDateFormat()));
+
+        // Table Prefix settings
+        $this->withTablePrefix($this->config('table_prefix', $this->getDefaultTablePrefix()));
 
         return $this;
     }
@@ -460,7 +468,7 @@ class Model
      */
     public function getRecordName()
     {
-        return Str::singular($this->blueprint->table());
+        return Str::singular($this->removeTablePrefix($this->blueprint->table()));
     }
 
     /**
@@ -640,8 +648,35 @@ class Model
      */
     public function needsTableName()
     {
-        return $this->blueprint->table() != Str::plural($this->getRecordName()) ||
+        return $this->shouldRemoveTablePrefix() || $this->blueprint->table() != Str::plural($this->getRecordName()) ||
                $this->shouldQualifyTableName();
+    }
+
+    /**
+     * @return string
+     */
+    public function shouldRemoveTablePrefix()
+    {
+        return !empty($this->tablePrefix);
+    }
+
+    /**
+     * @param string $tablePrefix
+     */
+    public function withTablePrefix($tablePrefix)
+    {
+        $this->tablePrefix = $tablePrefix;
+    }
+
+    /**
+     * @param string $table
+     */
+    public function removeTablePrefix($table)
+    {
+        if (($this->shouldRemoveTablePrefix()) && (substr($table,0,strlen($this->tablePrefix)) == $this->tablePrefix)) {
+          $table = substr($table,strlen($this->tablePrefix));
+        }
+        return $table;
     }
 
     /**
@@ -818,6 +853,14 @@ class Model
     public function getDefaultDateFormat()
     {
         return 'Y-m-d H:i:s';
+    }
+
+    /**
+     * @return string
+     */
+    public function getDefaultTablePrefix()
+    {
+        return '';
     }
 
     /**

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -358,8 +358,12 @@ class Model
     /**
      * @return string
      */
-    public function getTable()
+    public function getTable($andRemovePrefix=false)
     {
+        if ($andRemovePrefix)
+        {
+            return $this->removeTablePrefix($this->blueprint->table());
+        }
         return $this->blueprint->table();
     }
 

--- a/src/Coders/Model/Relations/BelongsToMany.php
+++ b/src/Coders/Model/Relations/BelongsToMany.php
@@ -73,10 +73,10 @@ class BelongsToMany implements Relation
     public function name()
     {
         if ($this->parent->usesSnakeAttributes()) {
-            return Str::snake(Str::plural(Str::singular($this->reference->getTable())));
+            return Str::snake(Str::plural(Str::singular($this->reference->getTable(true))));
         }
 
-        return Str::camel(Str::plural(Str::singular($this->reference->getTable())));
+        return Str::camel(Str::plural(Str::singular($this->reference->getTable(true))));
     }
 
     /**

--- a/src/Coders/Model/Relations/HasMany.php
+++ b/src/Coders/Model/Relations/HasMany.php
@@ -26,10 +26,10 @@ class HasMany extends HasOneOrMany
     public function name()
     {
         if ($this->parent->usesSnakeAttributes()) {
-            return Str::snake(Str::plural(Str::singular($this->related->getTable())));
+            return Str::snake(Str::plural(Str::singular($this->related->getTable(true))));
         }
 
-        return Str::camel(Str::plural(Str::singular($this->related->getTable())));
+        return Str::camel(Str::plural(Str::singular($this->related->getTable(true))));
     }
 
     /**


### PR DESCRIPTION
It's fairly common that table names are prefixed in some way, e.g. Wordpress with wp_tablename as a default. Running model generation on such tables results in the model names including the prefix e.g. `WpLink` from the `wp_links` table. This is undesirable so I've added support for a specified table prefix in the config file, which is then stripped from model and relation names, so we have the much nicer `Link` model and `links` relation.